### PR TITLE
fix: make xml_escape encode not decode

### DIFF
--- a/src/escape-xml.js
+++ b/src/escape-xml.js
@@ -2,6 +2,6 @@ import { AllHtmlEntities as Entities } from 'html-entities'
 
 const entities = new Entities()
 
-const escapeXML = (str) => entities.decode(str)
+const escapeXML = (str) => entities.encode(str)
 
 export default escapeXML

--- a/src/escape-xml.test.js
+++ b/src/escape-xml.test.js
@@ -1,8 +1,8 @@
 import test from 'ava'
 import escapeXML from './escape-xml'
 
-test('parses string correctly', (t) => {
-  const str = '&lt;Hey&mdash;there!&gt;'
-  const parsedStr = escapeXML(str)
-  t.is(parsedStr, '<Hey—there!>')
+test('escapes string correctly', (t) => {
+  const str = '<Hey—there!>'
+  const escapedStr = escapeXML(str)
+  t.is(escapedStr, '&lt;Hey&mdash;there!&gt;')
 })


### PR DESCRIPTION
`xml_escape` was implemented backwards. It converted encoded HTML (like `&lt;html&gt;`) to HTML (like `<html>`), when what you need in an XML file (and what Jekyll's `xml_escape` filter does) is the opposite: converting HTML (like `<html>`) to XML-encoded HTML (like `&lt;html&gt;'`).

Fixes #6.