### PR TITLE
Fix HTML entities

### DIFF
--- a/src/escape-xml.js
+++ b/src/escape-xml.js
@@ -1,4 +1,4 @@
-import { AllHtmlEntities as Entities } from 'html-entities'
+import { XmlEntities as Entities } from 'html-entities'
 
 const entities = new Entities()
 

--- a/src/escape-xml.js
+++ b/src/escape-xml.js
@@ -2,6 +2,6 @@ import { AllHtmlEntities as Entities } from 'html-entities'
 
 const entities = new Entities()
 
-const escapeXML = (str) => entities.decode(str)
+const escapeXML = (str) => entities.encode(str)
 
 export default escapeXML

--- a/src/escape-xml.test.js
+++ b/src/escape-xml.test.js
@@ -1,8 +1,14 @@
 import test from 'ava'
 import escapeXML from './escape-xml'
 
-test('escapes string correctly', (t) => {
-  const str = '<Hey—there!>'
+test('escapes HTML tags', (t) => {
+  const str = '<html>'
   const escapedStr = escapeXML(str)
-  t.is(escapedStr, '&lt;Hey&mdash;there!&gt;')
+  t.is(escapedStr, '&lt;html&gt;')
+})
+
+test('does not escape HTML entities that are invalid in XML', (t) => {
+  const str = 'No need to encode “curly quotes” in XML!'
+  const escapedStr = escapeXML(str)
+  t.is(escapedStr, 'No need to encode “curly quotes” in XML!')
 })

--- a/src/escape-xml.test.js
+++ b/src/escape-xml.test.js
@@ -1,8 +1,8 @@
 import test from 'ava'
 import escapeXML from './escape-xml'
 
-test('parses string correctly', (t) => {
-  const str = '&lt;Hey&mdash;there!&gt;'
-  const parsedStr = escapeXML(str)
-  t.is(parsedStr, '<Hey—there!>')
+test('escapes string correctly', (t) => {
+  const str = '<Hey—there!>'
+  const escapedStr = escapeXML(str)
+  t.is(escapedStr, '&lt;Hey&mdash;there!&gt;')
 })


### PR DESCRIPTION
While fixing #6, I also discovered that the `AllHtmlEntities` encoder being used from html-entities would generate entities like `&mdash;` that are invalid in XML. This PR further fixes that behaviour.

Fixes #6.